### PR TITLE
Small typo in mathdoc.rst

### DIFF
--- a/doc/mathdoc.rst
+++ b/doc/mathdoc.rst
@@ -472,7 +472,7 @@ These Sections are Cost, Commodity, Process, Transmission and Storage.
 	+------------------------------------+------+----------------------------------+
 	| :math:`\epsilon_{vst}^\text{con}`  | MWh  | Storage Energy Content           |
 	+------------------------------------+------+----------------------------------+
-	| **Demand Side Management Variables                                           |
+	| **Demand Side Management Variables**                                         |
 	+------------------------------------+------+----------------------------------+
 	| :math:`\delta_{vct}^\text{up}`     | MW   | DSM Upshift                      |
 	+------------------------------------+------+----------------------------------+


### PR DESCRIPTION
Just forgot '**' at the end of a headline...