### PR TITLE
Intermittent_supply_rule as equation (fix #132)

### DIFF
--- a/urbs/model.py
+++ b/urbs/model.py
@@ -825,7 +825,7 @@ def def_process_output_rule(m, tm, sit, pro, co):
 # process input (for supim commodity) = process capacity * timeseries
 def def_intermittent_supply_rule(m, tm, sit, pro, coin):
     if coin in m.com_supim:
-        return (m.e_pro_in[tm, sit, pro, coin] <=
+        return (m.e_pro_in[tm, sit, pro, coin] ==
                 m.cap_pro[sit, pro] * m.supim.loc[tm][sit, coin])
     else:
         return pyomo.Constraint.Skip


### PR DESCRIPTION
* Intermittent supply rule in model.py changed to equation instead of changing the documentation.