### PR TITLE
Changes in model intern naming of 'Global' sheet

### DIFF
--- a/urbs/input.py
+++ b/urbs/input.py
@@ -22,7 +22,7 @@ def read_excel(filename):
 
     Example:
         >>> data = read_excel('mimo-example.xlsx')
-        >>> data['global'].loc['CO2 limit', 'value']
+        >>> data['global_prop'].loc['CO2 limit', 'value']
         150000000
     """
     with pd.ExcelFile(filename) as xls:
@@ -43,7 +43,7 @@ def read_excel(filename):
         supim = xls.parse('SupIm').set_index(['t'])
         buy_sell_price = xls.parse('Buy-Sell-Price').set_index(['t'])
         dsm = xls.parse('DSM').set_index(['Site', 'Commodity'])
-        glob_prop = xls.parse('Global').set_index(['Property'])
+        global_prop = xls.parse('Global').set_index(['Property'])
 
     # prepare input data
     # split columns by dots '.', so that 'DE.Elec' becomes the two-level
@@ -53,7 +53,7 @@ def read_excel(filename):
     buy_sell_price.columns = split_columns(buy_sell_price.columns, '.')
 
     data = {
-        'glob_prop': glob_prop,
+        'global_prop': global_prop,
         'site': site,
         'commodity': commodity,
         'process': process,

--- a/urbs/input.py
+++ b/urbs/input.py
@@ -43,7 +43,7 @@ def read_excel(filename):
         supim = xls.parse('SupIm').set_index(['t'])
         buy_sell_price = xls.parse('Buy-Sell-Price').set_index(['t'])
         dsm = xls.parse('DSM').set_index(['Site', 'Commodity'])
-        glob = xls.parse('Global').set_index(['Property'])
+        glob_prop = xls.parse('Global').set_index(['Property'])
 
     # prepare input data
     # split columns by dots '.', so that 'DE.Elec' becomes the two-level
@@ -53,7 +53,7 @@ def read_excel(filename):
     buy_sell_price.columns = split_columns(buy_sell_price.columns, '.')
 
     data = {
-        'global': glob,
+        'glob_prop': glob_prop,
         'site': site,
         'commodity': commodity,
         'process': process,

--- a/urbs/model.py
+++ b/urbs/model.py
@@ -33,7 +33,7 @@ def create_model(data, timesteps=None, dt=1, dual=False):
     #
     #     m.storage.loc[site, storage, commodity][attribute]
     #
-    m.glob_prop = data['glob_prop'].drop('description', axis=1)
+    m.global_prop = data['global_prop'].drop('description', axis=1)
     m.site = data['site']
     m.commodity = data['commodity']
     m.process = data['process']
@@ -1031,9 +1031,9 @@ def res_initial_and_final_storage_state_rule(m, t, sit, sto, com):
 
 # total CO2 output <= Global CO2 limit
 def res_global_co2_limit_rule(m):
-    if math.isinf(m.glob_prop.loc['CO2 limit', 'value']):
+    if math.isinf(m.global_prop.loc['CO2 limit', 'value']):
         return pyomo.Constraint.Skip
-    elif m.glob_prop.loc['CO2 limit', 'value'] > 0:
+    elif m.global_prop.loc['CO2 limit', 'value'] > 0:
         co2_output_sum = 0
         for tm in m.tm:
             for sit in m.sit:
@@ -1044,7 +1044,7 @@ def res_global_co2_limit_rule(m):
 
         # scaling to annual output (cf. definition of m.weight)
         co2_output_sum *= m.weight
-        return (co2_output_sum <= m.glob_prop.loc['CO2 limit', 'value'])
+        return (co2_output_sum <= m.global_prop.loc['CO2 limit', 'value'])
     else:
         return pyomo.Constraint.Skip
 

--- a/urbs/model.py
+++ b/urbs/model.py
@@ -33,7 +33,7 @@ def create_model(data, timesteps=None, dt=1, dual=False):
     #
     #     m.storage.loc[site, storage, commodity][attribute]
     #
-    m.glob = data['global'].drop('description', axis=1)
+    m.glob_prop = data['glob_prop'].drop('description', axis=1)
     m.site = data['site']
     m.commodity = data['commodity']
     m.process = data['process']
@@ -584,7 +584,7 @@ def create_model(data, timesteps=None, dt=1, dual=False):
 
     m.res_global_co2_limit = pyomo.Constraint(
             rule=res_global_co2_limit_rule,
-            doc='total co2 commodity output <= global.Glocal CO2 limit')
+            doc='total co2 commodity output <= Global CO2 limit')
 
     if dual:
         m.dual = pyomo.Suffix(direction=pyomo.Suffix.IMPORT)
@@ -1031,9 +1031,9 @@ def res_initial_and_final_storage_state_rule(m, t, sit, sto, com):
 
 # total CO2 output <= Global CO2 limit
 def res_global_co2_limit_rule(m):
-    if math.isinf(m.glob.loc['CO2 limit', 'value']):
+    if math.isinf(m.glob_prop.loc['CO2 limit', 'value']):
         return pyomo.Constraint.Skip
-    elif m.glob.loc['CO2 limit', 'value'] > 0:
+    elif m.glob_prop.loc['CO2 limit', 'value'] > 0:
         co2_output_sum = 0
         for tm in m.tm:
             for sit in m.sit:
@@ -1044,7 +1044,7 @@ def res_global_co2_limit_rule(m):
 
         # scaling to annual output (cf. definition of m.weight)
         co2_output_sum *= m.weight
-        return (co2_output_sum <= m.glob.loc['CO2 limit', 'value'])
+        return (co2_output_sum <= m.glob_prop.loc['CO2 limit', 'value'])
     else:
         return pyomo.Constraint.Skip
 


### PR DESCRIPTION
The names 'global' and 'glob' were not ideal for the dataframe containing the data from the 'Global' input worksheet. They were chenged to 'global_prop' in all instances in the relevant files.