### PR TITLE
Import added to plot.py

### DIFF
--- a/urbs/plot.py
+++ b/urbs/plot.py
@@ -6,6 +6,7 @@ from random import random
 from .data import COLORS
 from .input import get_input
 from .output import get_constants, get_timeseries
+from .pyomoio import get_entity
 from .util import is_string
 
 


### PR DESCRIPTION
The function get_entity from pyomoio.py was added to import in plot.py. 

This normally never caused problems, however, the error safety line when either 'timesteps' or 'plot_periods' were not specified was useless before since the required function was not imported in plot.py.

This closes Issue #167 