### PR TITLE
Make runme.py's self-copy to result_dir reliable

### DIFF
--- a/runme.py
+++ b/runme.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
     # copy input file to result directory
     shutil.copyfile(input_file, os.path.join(result_dir, input_file))
     # copy runme.py to result directory
-    shutil.copyfile(__file__, os.path.join(result_dir, __file__))
+    shutil.copy(__file__, result_dir)
 
     # simulation timesteps
     (offset, length) = (3500, 168)  # time step selection


### PR DESCRIPTION
Using `os.path.join` with `__file__` is dangerous, i.e. not portable. On my machine (tm), `__file__` returns the file's absolute path, resulting a wrong target filename. Like usual, there is a post on Stack Overflow ([Python `__file__` attribute absolute or relative?](https://stackoverflow.com/a/7116925/2375855)) that elaborates on the details as to when you get what.

To make it more portable, I propose to switch from `shutil.copyfile` (target needs to be a full filename) to `shutil.copy` (target may be a directory, too). That way, the way `__file__` is expanded (absolute or
relative filename/path) does not matter: the file lands in *result_dir* as intended.