### PR TITLE
Urgent fix for the calculation of annuity factor

### DIFF
--- a/urbs/input.py
+++ b/urbs/input.py
@@ -135,15 +135,18 @@ def pyomo_model_prep(data, timesteps):
     m.r_out_min_fraction = m.r_out_min_fraction[m.r_out_min_fraction > 0]
 
     # derive annuity factor from WACC and depreciation duration
-    m.process['annuity-factor'] = annuity_factor(
-        m.process['depreciation'],
-        m.process['wacc'])
-    m.transmission['annuity-factor'] = annuity_factor(
-        m.transmission['depreciation'],
-        m.transmission['wacc'])
-    m.storage['annuity-factor'] = annuity_factor(
-        m.storage['depreciation'],
-        m.storage['wacc'])
+    m.process['annuity-factor'] = (m.process.apply(lambda x:
+                                   annuity_factor(x['depreciation'],
+                                                  x['wacc']),
+                                   axis=1))
+    m.transmission['annuity-factor'] = (m.transmission.apply(lambda x:
+                                        annuity_factor(x['depreciation'],
+                                                       x['wacc']),
+                                        axis=1))
+    m.storage['annuity-factor'] = (m.storage.apply(lambda x:
+                                   annuity_factor(x['depreciation'],
+                                                  x['wacc']),
+                                   axis=1))
 
     # Converting Data frames to dictionaries
     #

--- a/urbs/modelhelper.py
+++ b/urbs/modelhelper.py
@@ -20,7 +20,10 @@ def annuity_factor(n, i):
         0.09439
 
     """
-    return (1+i)**n * i / ((1+i)**n - 1)
+    if i == 0:
+        return 1 / n
+    else:
+        return (1+i)**n * i / ((1+i)**n - 1)
 
 
 def commodity_balance(m, tm, sit, com):


### PR DESCRIPTION
So far a wacc of 0 led to a 0/0 division in function annuity factor in modelhelper.py. This obviously caused problems with an unhelpful "Solver didn't exit normally" error.

The problem was fixed and the fix tested.

This fixes #193