### PR TITLE
Hotfix: backwards compatibility for storage_e2p

### DIFF
--- a/urbs/input.py
+++ b/urbs/input.py
@@ -156,8 +156,11 @@ def pyomo_model_prep(data, timesteps):
     m.stor_init_bound = m.stor_init_bound[m.stor_init_bound >= 0]
 
     # storages with fixed energy-to-power ratio
-    m.sto_ep_ratio = m.storage['ep-ratio']
-    m.sto_ep_ratio = m.sto_ep_ratio[m.sto_ep_ratio >= 0]
+    try:
+        m.sto_ep_ratio = m.storage['ep-ratio']
+        m.sto_ep_ratio = m.sto_ep_ratio[m.sto_ep_ratio >= 0]
+    except:
+        m.sto_ep_ratio = pd.DataFrame() 
     
     # derive annuity factor from WACC and depreciation duration
     m.process['annuity-factor'] = (m.process.apply(lambda x:

--- a/urbs/validation.py
+++ b/urbs/validation.py
@@ -62,21 +62,27 @@ def validate_input(data):
                   data['storage'].loc[index]['cap-up-c']):
             raise ValueError('Ensure cap_lo <= cap_up and inst_cap <= cap_up'
                              ' for all storage capacities.')
-
-    for index in data['storage'].index:
-        if pd.notna(data['storage'].loc[index]['ep-ratio']): 
-            if (data['storage'].loc[index]['cap-lo-p'] *
-                data['storage'].loc[index]['ep-ratio'] >
-                data['storage'].loc[index]['cap-up-c'] or
-                data['storage'].loc[index]['cap-up-p'] *
-                data['storage'].loc[index]['ep-ratio'] <
-                data['storage'].loc[index]['cap-lo-c']):
-                raise ValueError('Ensure that the upper and lower limits for'
-                             ' power and energy capacities of the storage '
-                             +str(index)+
-                             ' are consistent with the given energy-to'
-                             '-power ratio.')                             
-                             
+                                 
+    if 'ep-ratio' in list(data['storage']):
+        if (data['storage']['ep-ratio'] <= 0).any():
+            raise ValueError("In worksheet 'storage' all values in column 'ep-ratio'"
+                             " must be either positive (for a fixed energy-to-power"
+                             " ratio) or left empty for independent sizing of"
+                             " storage energy and power capacities.")    
+        for index in data['storage'].index:
+            if data['storage'].loc[index]['ep-ratio'] > 0: 
+                if (data['storage'].loc[index]['cap-lo-p'] *
+                    data['storage'].loc[index]['ep-ratio'] >
+                    data['storage'].loc[index]['cap-up-c'] or
+                    data['storage'].loc[index]['cap-up-p'] *
+                    data['storage'].loc[index]['ep-ratio'] <
+                    data['storage'].loc[index]['cap-lo-c']):
+                    raise ValueError('Ensure that the upper and lower limits for'
+                                ' power and energy capacities of the storage '
+                                +str(index)+
+                                ' are consistent with the given energy-to'
+                                '-power ratio.')
+        
     # Identify SupIm values larger than 1, which lead to an infeasible model
     if (data['supim'] > 1).sum().sum() > 0:
         raise ValueError('All values in Sheet SupIm must be <= 1.')


### PR DESCRIPTION
1) try-except for the cases, in which the input file does not contain the column 'ep-ratio'
2) pd.notna reverted to > 0 for older pandas versions