### PR TITLE
Changed logic in validation.py for site name consitency validation

### DIFF
--- a/urbs/validation.py
+++ b/urbs/validation.py
@@ -62,27 +62,28 @@ def validate_input(data):
                   data['storage'].loc[index]['cap-up-c']):
             raise ValueError('Ensure cap_lo <= cap_up and inst_cap <= cap_up'
                              ' for all storage capacities.')
-                                 
+
     if 'ep-ratio' in list(data['storage']):
         if (data['storage']['ep-ratio'] <= 0).any():
-            raise ValueError("In worksheet 'storage' all values in column 'ep-ratio'"
-                             " must be either positive (for a fixed energy-to-power"
-                             " ratio) or left empty for independent sizing of"
-                             " storage energy and power capacities.")    
+            raise ValueError("In worksheet 'storage' all values in column "
+                             "'ep-ratio' must be either positive (for a fixed "
+                             "energy-to-power ratio) or left empty for "
+                             "independent sizing of storage energy and power "
+                             "capacities.")
         for index in data['storage'].index:
-            if data['storage'].loc[index]['ep-ratio'] > 0: 
+            if data['storage'].loc[index]['ep-ratio'] > 0:
                 if (data['storage'].loc[index]['cap-lo-p'] *
                     data['storage'].loc[index]['ep-ratio'] >
                     data['storage'].loc[index]['cap-up-c'] or
                     data['storage'].loc[index]['cap-up-p'] *
                     data['storage'].loc[index]['ep-ratio'] <
                     data['storage'].loc[index]['cap-lo-c']):
-                    raise ValueError('Ensure that the upper and lower limits for'
-                                ' power and energy capacities of the storage '
-                                +str(index)+
-                                ' are consistent with the given energy-to'
-                                '-power ratio.')
-        
+                    raise ValueError('Ensure that the upper and lower limits '
+                                     'for power and energy capacities of the '
+                                     'storage ' + str(index) + ' are '
+                                     'consistent with the given '
+                                     'energy-to-power ratio.')
+
     # Identify SupIm values larger than 1, which lead to an infeasible model
     if (data['supim'] > 1).sum().sum() > 0:
         raise ValueError('All values in Sheet SupIm must be <= 1.')
@@ -104,28 +105,28 @@ def validate_input(data):
                        "correspondingly.")
 
     # Identify inconsistencies in site names throughout worksheets
-    for site in data['site'].index.tolist():
-        if site not in data['commodity'].index.levels[0].tolist():
+    for site in data['commodity'].index.levels[0].tolist():
+        if site not in data['site'].index.tolist():
             raise KeyError("All names in the column 'Site' in input worksheet "
                            "'Commodity' must be from the list of site names "
                            "specified in the worksheet 'Site'.")
 
-    for site in data['site'].index.tolist():
-        if site not in data['process'].index.levels[0].tolist():
+    for site in data['process'].index.levels[0].tolist():
+        if site not in data['site'].index.tolist():
             raise KeyError("All names in the column 'Site' in input worksheet "
                            "'Process' must be from the list of site names "
                            "specified in the worksheet 'Site'.")
 
     if not data['storage'].empty:
-        for site in data['site'].index.tolist():
-            if site not in data['storage'].index.levels[0].tolist():
+        for site in data['storage'].index.levels[0].tolist():
+            if site not in data['site'].index.tolist():
                 raise KeyError("All names in the column 'Site' in input "
                                "worksheet 'Storage' must be from the list of "
                                "site names specified in the worksheet 'Site'.")
 
     if not data['dsm'].empty:
-        for site in data['site'].index.tolist():
-            if site not in data['dsm'].index.levels[0].tolist():
+        for site in data['dsm'].index.levels[0].tolist():
+            if site not in data['site'].index.tolist():
                 raise KeyError("All names in the column 'Site' in input "
                                "worksheet 'DSM' must be from the list of site "
                                "names specified in the worksheet 'Site'.")


### PR DESCRIPTION
The validation of site name consitency was causing unwanted errors for many users. This occured e.g. when storages where defined for some but not all sites.

The logic is now changed so that the entry for 'site' in the index of the 'commodity', 'process', 'storage' and 'DSM' sheets is chaecked against the entries in worksheet 'site'. This was wrongly the other way arond before.

This solves #219
  