### PR TITLE
Fix plotting error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.pyc
+.idea/*
 result/*
 results/*
 doc/_build/*

--- a/urbs/features/transmission.py
+++ b/urbs/features/transmission.py
@@ -152,15 +152,15 @@ def transmission_balance(m, tm, stf, sit, com):
                 # exports increase balance
                 for stframe, site_in, site_out, transmission, commodity
                 in m.tra_tuples
-                if (site_in == sit and stframe == stf and commodity) ==
-                com) -
+                if (site_in == sit and stframe == stf and
+                    commodity == com)) -
             sum(m.e_tra_out[(tm, stframe, site_in, site_out,
                              transmission, com)]
                 # imports decrease balance
                 for stframe, site_in, site_out, transmission, commodity
                 in m.tra_tuples
-                if site_out == sit and stframe == stf and
-                commodity == com))
+                if (site_out == sit and stframe == stf and
+                    commodity == com)))
 
 
 # transmission cost function

--- a/urbs/output.py
+++ b/urbs/output.py
@@ -120,13 +120,13 @@ def get_timeseries(instance, stf, com, sites, timesteps=None):
 
     # PROCESS
     created = get_entity(instance, 'e_pro_out')
-    created = created.xs([stf, com], level=['stf', 'com']).loc[timesteps]
     try:
+        created = created.xs([stf, com], level=['stf', 'com']).loc[timesteps]
         created = created.unstack(level='sit')[sites].fillna(0).sum(axis=1)
         created = created.unstack(level='pro')
         created = drop_all_zero_columns(created)
     except KeyError:
-        created = pd.DataFrame(index=timesteps)
+        created = pd.DataFrame(index=timesteps[1:])
 
     consumed = get_entity(instance, 'e_pro_in')
     try:


### PR DESCRIPTION
If commodities, which only go into processes, are plotted, this leads to an error. 

This is fixed.