### PR TITLE
Urbs gui

### DIFF
--- a/Installer/setup_script.iss
+++ b/Installer/setup_script.iss
@@ -20,6 +20,10 @@ LicenseFile=..\LICENSE
 OutputBaseFilename=urbs_gui_setup
 Compression=lzma
 SolidCompression=yes
+; control the wizard steps
+DisableWelcomePage=no
+DisableDirPage=no
+DisableProgramGroupPage=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/doc/installer/installer.rst
+++ b/doc/installer/installer.rst
@@ -13,7 +13,7 @@ clean environment from scratch using conda.
 
 ::
 
-    conda create -n yourenvname python=x.x anaconda
+    conda create -n yourenvname python=x.x
 
 where:
 


### PR DESCRIPTION
- Remove "anaconda" from env creation in the installer documentation.
- Adjust the installer to always show the Directory page.