### PR TITLE
Bug fix of storage constraints

### DIFF
--- a/urbs/features/storage.py
+++ b/urbs/features/storage.py
@@ -106,13 +106,13 @@ def add_storage(m):
         m.sto_tuples,
         rule=res_storage_capacity_rule,
         doc='storage.cap-lo-c <= storage capacity <= storage.cap-up-c')
-    m.res_initial_and_final_storage_state = pyomo.Constraint(
-        m.t, m.sto_init_bound_tuples,
-        rule=res_initial_and_final_storage_state_rule,
+    m.def_initial_storage_state = pyomo.Constraint(
+        m.sto_init_bound_tuples,
+        rule=def_initial_storage_state_rule,
         doc='storage content initial == and final >= storage.init * capacity')
-    m.res_initial_and_final_storage_state_var = pyomo.Constraint(
-        m.t, m.sto_tuples - m.sto_init_bound_tuples,
-        rule=res_initial_and_final_storage_state_var_rule,
+    m.res_storage_state_cyclicity = pyomo.Constraint(
+        m.sto_tuples,
+        rule=res_storage_state_cyclicity_rule,
         doc='storage content initial <= final, both variable')
     m.def_storage_energy_power_ratio = pyomo.Constraint(
         m.sto_ep_ratio_tuples,
@@ -137,9 +137,8 @@ def def_storage_state_rule(m, t, stf, sit, sto, com):
             m.e_sto_out[t, stf, sit, sto, com] /
             m.storage_dict['eff-out'][(stf, sit, sto, com)])
 
+
 # storage capacity (for m.cap_sto_c expression)
-
-
 def def_storage_capacity_rule(m, stf, sit, sto, com):
     if m.mode['int']:
         if (sit, sto, com, stf) in m.inst_sto_tuples:
@@ -167,9 +166,8 @@ def def_storage_capacity_rule(m, stf, sit, sto, com):
 
     return cap_sto_c
 
+
 # storage power (for m.cap_sto_p expression)
-
-
 def def_storage_power_rule(m, stf, sit, sto, com):
     if m.mode['int']:
         if (sit, sto, com, stf) in m.inst_sto_tuples:
@@ -198,9 +196,8 @@ def def_storage_power_rule(m, stf, sit, sto, com):
 
     return cap_sto_p
 
+
 # storage input <= storage power
-
-
 def res_storage_input_by_power_rule(m, t, stf, sit, sto, com):
     return (m.e_sto_in[t, stf, sit, sto, com] <= m.dt *
             m.cap_sto_p[stf, sit, sto, com])
@@ -235,20 +232,13 @@ def res_storage_capacity_rule(m, stf, sit, sto, com):
 # initialization of storage content in first timestep t[1]
 # forced minimun  storage content in final timestep t[len(m.t)]
 # content[t=1] == storage capacity * fraction <= content[t=final]
-def res_initial_and_final_storage_state_rule(m, t, stf, sit, sto, com):
-    if t == m.t[1]:  # first timestep (Pyomo uses 1-based indexing)
-        return (m.e_sto_con[t, stf, sit, sto, com] ==
-                m.cap_sto_c[stf, sit, sto, com] *
-                m.storage_dict['init'][(stf, sit, sto, com)])
-    elif t == m.t[len(m.t)]:  # last timestep
-        return (m.e_sto_con[t, stf, sit, sto, com] >=
-                m.cap_sto_c[stf, sit, sto, com] *
-                m.storage_dict['init'][(stf, sit, sto, com)])
-    else:
-        return pyomo.Constraint.Skip
+def def_initial_storage_state_rule(m, stf, sit, sto, com):
+    return (m.e_sto_con[m.t[1], stf, sit, sto, com] ==
+            m.cap_sto_c[stf, sit, sto, com] *
+            m.storage_dict['init'][(stf, sit, sto, com)])
 
 
-def res_initial_and_final_storage_state_var_rule(m, t, stf, sit, sto, com):
+def res_storage_state_cyclicity_rule(m, stf, sit, sto, com):
     return (m.e_sto_con[m.t[1], stf, sit, sto, com] <=
             m.e_sto_con[m.t[len(m.t)], stf, sit, sto, com])
 
@@ -271,9 +261,8 @@ def storage_balance(m, tm, stf, sit, com):
                for stframe, site, storage, commodity in m.sto_tuples
                if site == sit and stframe == stf and commodity == com)
 
+
 # storage costs
-
-
 def storage_cost(m, cost_type):
     """returns storage cost function for the different cost types"""
     if cost_type == 'Invest':


### PR DESCRIPTION
* The constraint res_initial_and_final_storage_state_var is renamed to res_storage_state_cyclicity,
* res_storage_state_cyclicity now rightly takes no time index, and is applied for every storage unit
* The constraint res_initial_and_final_storage_state is renamed to def_initial_storage_state
* def_initial_storage_state now takes no time index, and only fixes the initial state of charge (for the storage units with a non-empty entry in column 'init')