### PR TITLE
Update comp.py debugged

### DIFF
--- a/comp.py
+++ b/comp.py
@@ -132,14 +132,14 @@ def compare_scenarios(result_files, output_filename):
             # repair broken MultiIndex in the first column
             esum.reset_index(inplace=True)
             esum.fillna(method='ffill', inplace=True)
-            esum.set_index(['level_0', 'level_1'], inplace=True)
+            esum.set_index(['Unnamed: 0','Unnamed: 1'], inplace=True)
 
             costs.append(cost)
 
             # extract sites and commodities from scenario
-            sitcom = [value.split('.') for value
+            yrsitcom = [value.split('.') for value
                       in esum.columns.get_level_values(0)]
-            coms = set([com for sit, com in sitcom])
+            coms = set([com for yr, sit, com in yrsitcom])
             com_sums = pd.DataFrame()
             # get site.commodity names
             sit_com = esum.columns.get_level_values(0)


### PR DESCRIPTION
line 135 the 'Commodity sums' has classifications(Created, Consumed etc.) in column1 and detailed processes and commodities in column2. And these columns have no name in Excel file. In esum dataframe the names of these columns are shown as 'Unnamed: 0' and 'Unnamed: 1'. And we set these columns as index by using '''esum.set_index(['Unnamed: 0','Unnamed: 1'], inplace=True)'''.

Line 140: The only column left in esum is the tuple comprised of year, site and commodity(Elec, CO2, etc.). So if we split this tuple we get for instance '2020', 'Mid', 'Elec'.
Since there are 3 values, I changed the name of the list from 'sitcom' to 'yrsitcom' so that I can extract 'com' out of yr, sit, com in yrsitcom in line 142.

The only problem left:
When I run the run_single_year.py, I get the values for '2020.North.Elec','2020.Mid.Elec','2020.South.Elec','2020.('North','Mid','South').Elec'. And these are the column names for the 'Commodity sums' as well. But weirdly the values for '2020.South.Elec' and '2020.('North','Mid','South').Elec' are exactly the same and they just duplicate each other. So in the 'Comparison' generated by comp.py the values for '2020.South.Elec' are doubled and we get an overestimated number for the created energy over the defined timesteps.